### PR TITLE
Fix exception when ranks is null

### DIFF
--- a/nomer/src/main/java/org/globalbioticinteractions/nomer/util/AppenderJSON.java
+++ b/nomer/src/main/java/org/globalbioticinteractions/nomer/util/AppenderJSON.java
@@ -28,7 +28,7 @@ public class AppenderJSON implements Appender {
                 ArrayNode ids = addArray(pathNode, "ids", taxon.getPathIds());
                 ArrayNode ranks = addArray(pathNode, "ranks", taxon.getPathNames());
                 if ((ids == null || names.size() == ids.size())
-                        && (names == null || names.size() == ranks.size())) {
+                        && (names == null || ranks == null || names.size() == ranks.size())) {
                     resolved.put("path", pathNode);
                 }
             }


### PR DESCRIPTION
Hi @jhpoelen,

using `nomer` I came to this exception:
``` 
java.lang.NullPointerException
    at org.globalbioticinteractions.nomer.util.AppenderJSON.lambda$appendLinesForRow$0(AppenderJSON.java:31)
    at java.base/java.util.stream.Streams$StreamBuilderImpl.forEachRemaining(Streams.java:411)
    at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
    at org.globalbioticinteractions.nomer.util.AppenderJSON.appendLinesForRow(AppenderJSON.java:22)
    at org.globalbioticinteractions.nomer.util.AppendingRowHandler.lambda$onRow$1(AppendingRowHandler.java:32)
    at org.eol.globi.service.TermMatcherHierarchical$1.foundTaxonForTerm(TermMatcherHierarchical.java:64)
    at org.eol.globi.taxon.TaxonCacheService.resolveName(TaxonCacheService.java:268)
    at org.eol.globi.taxon.TaxonCacheService.match(TaxonCacheService.java:245)
    at org.eol.globi.service.TermMatcherHierarchical.match(TermMatcherHierarchical.java:57)
    at org.globalbioticinteractions.nomer.util.AppendingRowHandler.onRow(AppendingRowHandler.java:30)
    at org.globalbioticinteractions.nomer.util.MatchUtil.apply(MatchUtil.java:52)
    at org.globalbioticinteractions.nomer.util.MatchUtil.match(MatchUtil.java:26)
    at org.globalbioticinteractions.nomer.cmd.CmdAppend.run(CmdAppend.java:38)
    at org.globalbioticinteractions.nomer.cmd.CmdLine.run(CmdLine.java:18)
    at org.globalbioticinteractions.nomer.cmd.CmdLine.run(CmdLine.java:27)
    at org.globalbioticinteractions.nomer.Nomer.main(Nomer.java:15)
```

After inspecting the code I realized that the `ArrayNode ranks` variable has `null` value, and then the `if` statement at line `30` raises an exception when trying to get the **size** of the `ranks` variable. 

Command to reproduce the error:

`echo -e "\tLemna sp." | nomer append -o json`

After adding the condiftion `|| ranks == null` to the `if` statement at line `30`, `nomer` produces the follow outputs:

```
{"norank":{"@id":"doi:10.3897/BDJ.2.e1019","name":"doi:10.3897/BDJ.2.e1019","equivalent_to":{"name":"Lemna sp."}},"path":{"names":["doi:10.3897/BDJ.2.e1019"]}}
```


I'm creating a pull request to fix it, but you may know better if this change will not broken things.

best,
josé.