### PR TITLE
Add support for multiple matchers

### DIFF
--- a/nomer/src/main/java/org/eol/globi/service/MultipleTermMatcher.java
+++ b/nomer/src/main/java/org/eol/globi/service/MultipleTermMatcher.java
@@ -1,0 +1,26 @@
+package org.eol.globi.service;
+
+import java.util.List;
+
+import org.eol.globi.domain.Term;
+import org.eol.globi.taxon.TermMatchListener;
+import org.eol.globi.taxon.TermMatcher;
+
+public class MultipleTermMatcher implements TermMatcher {
+
+	
+	private List<? extends TermMatcher> matchers;
+
+	public MultipleTermMatcher(List<? extends TermMatcher> matchers) {
+		this.matchers = matchers;
+	}
+	
+	@Override
+	public void match(List<Term> terms, TermMatchListener termMatchListener) throws PropertyEnricherException {		
+		for (TermMatcher matcher : this.matchers) {
+			matcher.match(terms, termMatchListener);			
+			
+		}		
+	}
+
+}


### PR DESCRIPTION
Add support to multiple matchers:

```bash
echo -e "\tHomo sapiens" | nomer append col gbif
	Homo sapiens	HAS_ACCEPTED_NAME	COL:6MB3T	Homo sapiens	Linnaeus, 1758	species		Biota | Animalia | Chordata | Vertebrata | Gnathostomata | Osteichthyes | Sarcopterygii | Tetrapoda | Amniota | Mammalia | Theria | Eutheria | Primates | Haplorrhini | Simiiformes | Hominoidea | Hominidae | Homininae | Homo | Homo sapiens	COL:5T6MX | COL:N | COL:CH2 | COL:8V4V3 | COL:8V4V5 | COL:8VVWB | COL:8VSMX | COL:9CK8W | COL:8VLBH | COL:6224G | COL:924GT | COL:LG | COL:8ZXYB | COL:4DT | COL:4PM | COL:58L | COL:6256T | COL:JPH | COL:636X2 | COL:6MB3T	unranked | kingdom | phylum | subphylum | infraphylum | parvphylum | gigaclass | megaclass | superclass | class | subclass | infraclass | order | suborder | infraorder | superfamily | family | subfamily | genus | species	|  |  |  |  |  |  |  |  | Linnaeus, 1758 | Parker & Haswell, 1897 | Gill, 1872 | Linnaeus, 1758 | Pocock, 1918 | Haeckel, 1866 | Gray, 1825 | Gray, 1825 | Gray, 1825 | Linnaeus, 1758 | Linnaeus, 1758	https://www.catalogueoflife.org/data/taxon/6MB3T
	Homo sapiens	HAS_ACCEPTED_NAME	GBIF:2436436	Homo sapiens	Linnaeus, 1758	species		Animalia | Chordata | Mammalia | Primates | Hominidae | Homo | Homo sapiens	GBIF:1 | GBIF:44 | GBIF:359 | GBIF:798 | GBIF:5483 | GBIF:2436435 | GBIF:2436436	kingdom | phylum | class | order | family | genus | species	|  |  |  |  | Linnaeus, 1758 | Linnaeus, 1758http://www.gbif.org/species/2436436
```


